### PR TITLE
provided an option to custom delimiter 

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -43,6 +43,14 @@ func WithIoReader(io io.ReadCloser) Reader {
 	return WithCsvReader(csvReader, io)
 }
 
+// WithIoReaderAndDelimiter creates a csv Reader from the specified io Reader.
+func WithIoReaderAndDelimiter(io io.ReadCloser, delimiter rune) Reader {
+	csvReader := csv.NewReader(io)
+	csvReader.Comma = delimiter
+	csvReader.FieldsPerRecord = -1
+	return WithCsvReader(csvReader, io)
+}
+
 // WithCsvReader creates a csv reader from the specified encoding/csv Reader.
 func WithCsvReader(r *csv.Reader, c io.Closer) Reader {
 	ch := make(chan Record)

--- a/writer.go
+++ b/writer.go
@@ -46,6 +46,13 @@ func WithIoWriter(w io.WriteCloser) WriterBuilder {
 	return WithCsvWriter(encoding.NewWriter(w), w)
 }
 
+// Answer a Writer for the CSV stream constrained by the specified header, using the specified io writer and delimiter.
+func WithIoWriterAndDelimiter(w io.WriteCloser, delimiter rune) WriterBuilder {
+	writer := encoding.NewWriter(w)
+	writer.Comma = delimiter
+	return WithCsvWriter(writer, w)
+}
+
 // Answer the header that constrains the output stream
 func (w *writer) Header() []string {
 	return w.header


### PR DESCRIPTION
This custom delimiter needed for getting input from user as a command line argument. I used with my go-diff tool